### PR TITLE
Add minimal HTML response endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,19 @@ SAMPLE_XML = <<~HEREDOC
 </message>
 HEREDOC
 
+SAMPLE_HTML = <<~HEREDOC
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Greetings Earthlings</title>
+</head>
+<body>
+  <p>Hello World !</p>
+</body>
+</html>
+HEREDOC
+
 SAMPLE_JSON = { life: 42, foo: 'bar', false: true, pi: 13.37 }.to_json
 
 KNOWN_HTTP_CODES = {
@@ -112,6 +125,11 @@ end
 get '/xml' do
   content_type :xml
   SAMPLE_XML
+end
+
+get '/html' do
+  content_type :html
+  SAMPLE_HTML
 end
 
 get '/infinite' do

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -69,6 +69,13 @@ class MainAppTest < Minitest::Test
     assert last_response.body.include?(SAMPLE_XML)
   end
 
+  def test_html
+    get '/html'
+
+    assert last_response.ok?
+    assert last_response.body.include?(SAMPLE_HTML)
+  end
+
   def test_json
     get '/json'
 


### PR DESCRIPTION
We have endpoints for all HTTP status codes but no response body.

Adding this simple HTML 5 response will help against HTML parsing (for PhantomJS for instance).