### PR TITLE
Optimize sample XML response for most browser

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,7 +10,7 @@ SAMPLE_TEXT = <<~HEREDOC
 HEREDOC
 
 SAMPLE_XML = <<~HEREDOC
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <message>
   <from>Alice</from>
   <to>Bob</to>


### PR DESCRIPTION
PhantomJS 2.1.1 on Ubuntu responds with

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<message>
<from>Alice</from>
<to>Bob</to>
<body>Hello</body>
</message>
```

When he fetches this XML :

```
<?xml version="1.0" encoding="UTF-8"?>
<message>
<from>Alice</from>
<to>Bob</to>
<body>Hello</body>
</message>
```

By adding the standalone attribute to the xml tag, we make the response
identical on macOS (dev / test) and Linux (CI / production).