### PR TITLE
Add a local_redirect action to simulation redir without scheme/host

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -136,3 +136,8 @@ get '/slow' do
 
   'Hello, tired!'
 end
+
+get '/local-redirect' do
+ response.headers['Location'] = '/code/200'
+ halt 302
+end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -90,6 +90,14 @@ class MainAppTest < Minitest::Test
     assert last_response.body.include?(SAMPLE_TEXT)
   end
 
+  def test_local_redirect
+    get '/local-redirect'
+    follow_redirect!
+
+    assert last_response.ok?
+    assert last_response.body.include?('OK')
+  end
+
   private
 
   def no_body_expected?(code)


### PR DESCRIPTION
Simulate behavior of many sites making HTTP redirection with a relative URL.
Application root redirection is making a absolute redir.

```
❯ curl -I http://localhost:5000
HTTP/1.1 303 See Other
Content-Type: text/html;charset=utf-8
Location: http://localhost:5000/code/200
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Content-Length: 0

❯ curl -I http://localhost:5000/local-redirect
HTTP/1.1 302 Found
Content-Type: text/html;charset=utf-8
Location: /code/200
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Content-Length: 0
```


May be naming should be adapted to be more comprehensible.