### PR TITLE
Unify behavior to match dummy http

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+AllCops:
+  TargetRubyVersion: 2.4.1
+
+# Really negligible performance gain with double quotes
+# Painfull everyday usage
+Style/StringLiterals:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 ruby '2.4.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'bundler'
 require 'bundler/setup'
 require 'rake/testtask'
- 
+
 Rake::TestTask.new do |t|
   t.pattern = 'test/*_test.rb'
 end
 
-task :default => [:test]
+task default: [:test]

--- a/app.rb
+++ b/app.rb
@@ -139,7 +139,7 @@ get "/redirection/infinite" do
 end
 
 get "/redirection/temporary" do
-  redirect to("/redirection/temporary"), 301
+  redirect to("/html"), 301
 end
 
 get "/redirection/local" do

--- a/app.rb
+++ b/app.rb
@@ -1,143 +1,151 @@
 # frozen_string_literal: true
-require 'bundler'
-require 'bundler/setup'
-require 'sinatra'
-require 'json'
+
+require "bundler"
+require "bundler/setup"
+require "sinatra"
+require "json"
 
 SAMPLE_TEXT = <<~HEREDOC
   Stand up for what you believe in, even if it means standing alone.
   — Andy Biersack
-HEREDOC
+  HEREDOC
 
 SAMPLE_XML = <<~HEREDOC
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<message>
-  <from>Alice</from>
-  <to>Bob</to>
-  <body>Hello</body>
-</message>
-HEREDOC
+  <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+  <message>
+    <from>Alice</from>
+    <to>Bob</to>
+    <body>Hello</body>
+  </message>
+  HEREDOC
 
 SAMPLE_HTML = <<~HEREDOC
-<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Hi</title></head>
-<body><p>Hello World !</p></body>
-</html>
-HEREDOC
+  <!doctype html>
+  <html lang="en">
+  <head><meta charset="utf-8"><title>Hi</title></head>
+  <body><p>Hello World !</p></body>
+  </html>
+  HEREDOC
 
-SAMPLE_JSON = { life: 42, foo: 'bar', false: true, pi: 13.37 }.to_json
+SAMPLE_JSON = { life: 42, foo: "bar", false: true, pi: 13.37 }.to_json
 
 KNOWN_HTTP_CODES = {
-  200 => 'OK',
-  201 => 'Created',
-  202 => 'Accepted',
-  203 => 'Non-Authoritative Information',
-  204 => 'No Content',
-  205 => 'Reset Content',
-  206 => 'Partial Content',
-  207 => 'Multi-Status',
-  210 => 'Content Different',
-  226 => 'IM Used',
-  300 => 'Multiple Choices',
-  301 => 'Moved Permanently',
-  302 => 'Moved Temporarily',
-  303 => 'See Other',
-  304 => 'Not Modified',
-  305 => 'Use Proxy',
-  307 => 'Temporary Redirect',
-  308 => 'Permanent Redirect',
-  310 => 'Too many Redirects',
-  400 => 'Bad Request',
-  401 => 'Unauthorized',
-  402 => 'Payment Required',
-  403 => 'Forbidden',
-  404 => 'Not Found',
-  405 => 'Method Not Allowed',
-  406 => 'Not Acceptable',
-  407 => 'Proxy Authenticat,ion Required',
-  408 => 'Request Time-out',
-  409 => 'Conflict',
-  410 => 'Gone',
-  411 => 'Length Required',
-  412 => 'Precondition Failed',
-  413 => 'Request Entity Too Large',
-  414 => 'Request-URI Too Long',
-  415 => 'Unsupported Media Type',
-  416 => 'Requested range unsatisfiable',
-  417 => 'Expectation failed',
-  418 => 'I’m a teapot',
-  421 => 'Bad mapping / Misdirected Reque',
-  422 => 'Unprocessable entity',
-  423 => 'Locked',
-  424 => 'Method failure',
-  425 => 'Unordered Collection',
-  426 => 'Upgrade Required',
-  428 => 'Precondition Required',
-  429 => 'Too Many Requests',
-  431 => 'Request Header Fields Too La',
-  449 => 'Retry With',
-  450 => 'Blocked by Windows Parental Controls',
-  451 => 'Unavailable For Legal Reasons',
-  456 => 'Unrecoverable Error',
-  499 => 'client has closed connection',
-  500 => 'Internal Server Error',
-  501 => 'Not Implemented',
-  502 => 'Bad Gateway ou Proxy Error',
-  503 => 'Service Unavailable',
-  504 => 'Gateway Time-out',
-  505 => 'HTTP Version not supported',
-  506 => 'Variant also negociate',
-  507 => 'Insufficient storage',
-  508 => 'Loop detected',
-  509 => 'Bandwidth Limit Exceeded',
-  510 => 'Not extended',
-  511 => 'Network authentication required',
-  520 => 'Web server is returning an unknown error'
+  200 => "OK",
+  201 => "Created",
+  202 => "Accepted",
+  203 => "Non-Authoritative Information",
+  204 => "No Content",
+  205 => "Reset Content",
+  206 => "Partial Content",
+  207 => "Multi-Status",
+  210 => "Content Different",
+  226 => "IM Used",
+  300 => "Multiple Choices",
+  301 => "Moved Permanently",
+  302 => "Moved Temporarily",
+  303 => "See Other",
+  304 => "Not Modified",
+  305 => "Use Proxy",
+  307 => "Temporary Redirect",
+  308 => "Permanent Redirect",
+  310 => "Too many Redirects",
+  400 => "Bad Request",
+  401 => "Unauthorized",
+  402 => "Payment Required",
+  403 => "Forbidden",
+  404 => "Not Found",
+  405 => "Method Not Allowed",
+  406 => "Not Acceptable",
+  407 => "Proxy Authenticat,ion Required",
+  408 => "Request Time-out",
+  409 => "Conflict",
+  410 => "Gone",
+  411 => "Length Required",
+  412 => "Precondition Failed",
+  413 => "Request Entity Too Large",
+  414 => "Request-URI Too Long",
+  415 => "Unsupported Media Type",
+  416 => "Requested range unsatisfiable",
+  417 => "Expectation failed",
+  418 => "I’m a teapot",
+  421 => "Bad mapping / Misdirected Reque",
+  422 => "Unprocessable entity",
+  423 => "Locked",
+  424 => "Method failure",
+  425 => "Unordered Collection",
+  426 => "Upgrade Required",
+  428 => "Precondition Required",
+  429 => "Too Many Requests",
+  431 => "Request Header Fields Too La",
+  449 => "Retry With",
+  450 => "Blocked by Windows Parental Controls",
+  451 => "Unavailable For Legal Reasons",
+  456 => "Unrecoverable Error",
+  499 => "client has closed connection",
+  500 => "Internal Server Error",
+  501 => "Not Implemented",
+  502 => "Bad Gateway ou Proxy Error",
+  503 => "Service Unavailable",
+  504 => "Gateway Time-out",
+  505 => "HTTP Version not supported",
+  506 => "Variant also negociate",
+  507 => "Insufficient storage",
+  508 => "Loop detected",
+  509 => "Bandwidth Limit Exceeded",
+  510 => "Not extended",
+  511 => "Network authentication required",
+  520 => "Web server is returning an unknown error"
 }.freeze
 
-get '/' do
-  redirect '/code/200'
+get "/" do
+  redirect to("/html")
 end
 
-get '/code/:http_code' do
-  code = params['http_code'].to_i
+get "/code/:http_code" do
+  code = params["http_code"].to_i
   code = KNOWN_HTTP_CODES.keys.include?(code) ? code : 200
 
   halt code, KNOWN_HTTP_CODES[code.to_i]
 end
 
-get '/json' do
+get "/json" do
   content_type :json
   SAMPLE_JSON
 end
 
-get '/text' do
+get "/text" do
   content_type :text
   SAMPLE_TEXT
 end
 
-get '/xml' do
+get "/xml" do
   content_type :xml
   SAMPLE_XML
 end
 
-get '/html' do
+get "/html" do
   content_type :html
   SAMPLE_HTML
 end
 
-get '/infinite' do
-  redirect '/infinite'
+get "/slow" do
+  sleep 10
+  content_type :text
+  "Hello, tired!"
 end
 
-get '/slow' do
-  sleep 5
-
-  'Hello, tired!'
+get "/redirection/infinite" do
+  redirect to("/redirection/infinite")
 end
 
-get '/local-redirect' do
- response.headers['Location'] = '/code/200'
- halt 302
+get "/redirection/temporary" do
+  redirect to("/redirection/temporary"), 301
+end
+
+get "/redirection/local" do
+  redirect to("/html")
+end
+
+get "/redirection/other_domain" do
+  redirect "https://www.google.fr"
 end

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require_relative 'app'
 
 set :environment, ENV['RACK_ENV'].to_sym
 set :bind, '0.0.0.0'
 
 run Sinatra::Application
-

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 3)
 threads threads_count, threads_count

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -116,6 +116,13 @@ class MainAppTest < Minitest::Test
     assert_equal last_response.headers["Location"], 'http://example.org/html'
   end
 
+  def test_redirection_to_other_domain
+    get '/redirection/other_domain'
+
+    assert_equal last_response.status, 302
+    assert_equal last_response.headers["Location"], 'https://www.google.fr'
+  end
+
   def test_infinite_redirection
     get "/redirection/infinite"
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RACK_ENV'] = 'test'
 
 # Local code coverage analysis
@@ -36,66 +38,69 @@ class MainAppTest < Minitest::Test
     follow_redirect!
 
     assert last_response.ok?
-    assert last_response.body.include?('OK')
+    assert_includes last_response.body, 'Hello World'
   end
 
   KNOWN_HTTP_CODES.each do |code, content|
     define_method "test_#{code}_response" do
       get "/code/#{code}"
 
-      assert last_response.status == code
-      assert last_response.body.include?(content) unless no_body_expected?(code)
+      assert_equal last_response.status, code
+      assert_includes(last_response.body, content) unless no_body_expected?(code)
     end
   end
 
   def test_slow_response
+    before_time = Time.now
     get '/slow'
+    after_time = Time.now
+    duration   = after_time.to_f - before_time.to_f
 
     assert last_response.ok?
-    assert last_response.body.include?('Hello, tired!')
-  end
-
-  def test_infinite_response
-    get '/infinite'
-
-    assert last_response.status == 302
-    assert_equal 'http://example.org/infinite', last_request.url
+    assert_includes last_response.body, 'Hello, tired!'
+    assert_operator duration, :>=, 10.0
   end
 
   def test_xml
     get '/xml'
 
     assert last_response.ok?
-    assert last_response.body.include?(SAMPLE_XML)
+    assert_includes last_response.body, SAMPLE_XML
+    assert_equal last_response.body.size, SAMPLE_XML.size
   end
 
   def test_html
     get '/html'
 
     assert last_response.ok?
-    assert last_response.body.include?(SAMPLE_HTML)
+    assert_includes last_response.body, SAMPLE_HTML
+    assert_equal last_response.body.size, SAMPLE_HTML.size
   end
 
   def test_json
     get '/json'
 
     assert last_response.ok?
-    assert last_response.body.include?(SAMPLE_JSON)
+    assert_includes last_response.body, SAMPLE_JSON
+    assert_equal last_response.body.size, SAMPLE_JSON.size
   end
 
   def test_text
     get '/text'
 
     assert last_response.ok?
-    assert last_response.body.include?(SAMPLE_TEXT)
+    assert_includes last_response.body, SAMPLE_TEXT
+    assert_equal last_response.body.size, SAMPLE_TEXT.size
   end
 
-  def test_local_redirect
-    get '/local-redirect'
+  def test_local_redirection_with_follow_redirect
+    get '/redirection/local'
     follow_redirect!
 
     assert last_response.ok?
-    assert last_response.body.include?('OK')
+    assert_equal last_request.url, 'http://example.org/html'
+    assert_includes last_response.body, 'Hello World'
+  end
   end
 
   private

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -101,6 +101,19 @@ class MainAppTest < Minitest::Test
     assert_equal last_request.url, 'http://example.org/html'
     assert_includes last_response.body, 'Hello World'
   end
+
+  def test_local_redirection_without_follow_redirect
+    get '/redirection/local'
+
+    assert_equal last_response.status, 302
+    assert_equal last_response.headers["Location"], 'http://example.org/html'
+  end
+
+  def test_infinite_redirection
+    get "/redirection/infinite"
+
+    assert_equal last_response.status, 302
+    assert_equal last_request.url, 'http://example.org/redirection/infinite'
   end
 
   private

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -109,6 +109,13 @@ class MainAppTest < Minitest::Test
     assert_equal last_response.headers["Location"], 'http://example.org/html'
   end
 
+  def test_temporary_redirection
+    get '/redirection/temporary'
+
+    assert_equal last_response.status, 301
+    assert_equal last_response.headers["Location"], 'http://example.org/html'
+  end
+
   def test_infinite_redirection
     get "/redirection/infinite"
 


### PR DESCRIPTION
This PR (breaking-)changes URLs to ensure we get the same explicit routes DummyHTTP initiated.

Other applications depending on this one should be updated as well.