### PR TITLE
Use latest jemalloc version via a new buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/mojodna/heroku-buildpack-jemalloc
+https://github.com/gaffneyc/heroku-buildpack-jemalloc
 https://github.com/Scalingo/ruby-buildpack
 


### PR DESCRIPTION
The buildpack sets its LD_PRELOAD env variable and compiles
jemalloc lib on deploy.