### PR TITLE
More specific case endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,5 +56,8 @@ DEPENDENCIES
   sinatra
   standard
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    2.0.2

--- a/app.rb
+++ b/app.rb
@@ -22,7 +22,20 @@ HEREDOC
 SAMPLE_HTML = <<~HEREDOC
   <!doctype html>
   <html lang="en">
-  <head><meta charset="utf-8"><title>Hi</title></head>
+  <head><meta charset="utf-8" /><title>Hi</title></head>
+  <body><p>Hello World !</p></body>
+  </html>
+HEREDOC
+
+SAMPLE_JS = <<~HEREDOC
+  console.log("hello")
+HEREDOC
+
+SAMPLE_HTML_JS_AD = <<~HEREDOC
+  <!doctype html>
+  <html lang="en">
+  <head><meta charset="utf-8" /><title>Hi</title></head>
+  <script language="javascript" src="/s_code.js"></script>
   <body><p>Hello World !</p></body>
   </html>
 HEREDOC
@@ -126,6 +139,21 @@ end
 get "/html" do
   content_type :html
   SAMPLE_HTML
+end
+
+get "/js" do
+  content_type :js
+  SAMPLE_JS
+end
+
+get "/s_code.js" do
+  content_type :js
+  SAMPLE_JS
+end
+
+get "/html_js_ad" do
+  content_type :html
+  SAMPLE_HTML_JS_AD
 end
 
 get "/slow" do

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -61,6 +61,30 @@ class MainAppTest < Minitest::Test
     assert_equal last_response.body.size, SAMPLE_HTML.size
   end
 
+  def test_js
+    get "/js"
+
+    assert last_response.ok?
+    assert_includes last_response.body, SAMPLE_JS
+    assert_equal last_response.body.size, SAMPLE_JS.size
+  end
+
+  def test_js_ad
+    get "/s_code.js"
+
+    assert last_response.ok?
+    assert_includes last_response.body, SAMPLE_JS
+    assert_equal last_response.body.size, SAMPLE_JS.size
+  end
+
+  def test_html_js_ad
+    get "/html_js_ad"
+
+    assert last_response.ok?
+    assert_includes last_response.body, SAMPLE_HTML_JS_AD
+    assert_equal last_response.body.size, SAMPLE_HTML_JS_AD.size
+  end
+
   def test_json
     get "/json"
 


### PR DESCRIPTION
Preparing levups/nazgul#534

adding a `/js` endpoint, a `/s_code.js` which is supposed to be filtered by ad-blocked, and a `/html_js_ad` which compose html with `s_code.js` call to check for correct ad-blocking.